### PR TITLE
Foi feita a remocao de aspas apenas quando for um arquivo

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -33,9 +33,8 @@ class Report extends Element {
 
 
     public function __construct($xmlFile = null,$param) {
-        $xmlFile = str_ireplace(array('"'), array(''), $xmlFile);
         if(file_exists(self::$defaultFolder.DIRECTORY_SEPARATOR.$xmlFile)) {
-            
+            $xmlFile = str_ireplace(array('"'), array(''), $xmlFile);
             $xmlFile = file_get_contents(self::$defaultFolder.DIRECTORY_SEPARATOR.$xmlFile);
         }
         $keyword = "<queryString>


### PR DESCRIPTION
Foi feita a remocao de aspas apenas quando for um arquivo, pois quando eu estiver carregando uma string estava removendo as aspas de dentro do proprio xml