### PR TITLE
* use clipping to crop text elements / fix rotation

### DIFF
--- a/src/StaticText.php
+++ b/src/StaticText.php
@@ -96,6 +96,25 @@ class StaticText extends Element {
         if (isset($data->reportElement["key"])) {
             $height = $fontsize * $this->adjust;
         }
+        $lineHeightRatio = 1;
+        if (isset($data->textElement->paragraph["lineSpacing"])) {
+            switch ($data->textElement->paragraph["lineSpacing"]) {
+                case "1_1_2":
+                    $lineHeightRatio = 1.5;
+                    break;
+                case "Double":
+                    $lineHeightRatio = 1.5;
+                    break;
+                case "Proportional":
+                    $lineHeightRatio = $data->textElement->paragraph["lineSpacingSize"];
+                    break;
+            }
+        }
+
+        JasperPHP\Instructions::addInstruction(array(
+            "type" => "setCellHeightRatio",
+            "ratio" => $lineHeightRatio
+        ));
         JasperPHP\Instructions::addInstruction(array("type" => "SetXY", "x" => $data->reportElement["x"] + 0, "y" => $data->reportElement["y"] + 0, "hidden_type" => "SetXY"));
         JasperPHP\Instructions::addInstruction(array("type" => "SetTextColor", 'forecolor' => $data->reportElement["forecolor"] . '', "r" => $textcolor["r"], "g" => $textcolor["g"], "b" => $textcolor["b"], "hidden_type" => "textcolor"));
         JasperPHP\Instructions::addInstruction(array("type" => "SetDrawColor", "r" => $drawcolor["r"], "g" => $drawcolor["g"], "b" => $drawcolor["b"], "hidden_type" => "drawcolor"));

--- a/src/TextField.php
+++ b/src/TextField.php
@@ -109,7 +109,24 @@ class TextField extends Element {
         if (isset($data->textElement->font["isUnderline"]) && $data->textElement->font["isUnderline"] == "true") {
             $fontstyle = $fontstyle . "U";
         }
-
+        $lineHeightRatio = 1;
+        if (isset($data->textElement->paragraph["lineSpacing"])) {
+            switch ($data->textElement->paragraph["lineSpacing"]) {
+                case "1_1_2":
+                    $lineHeightRatio = 1.5;
+                    break;
+                case "Double":
+                    $lineHeightRatio = 1.5;
+                    break;
+                case "Proportional":
+                    $lineHeightRatio = $data->textElement->paragraph["lineSpacingSize"];
+                    break;
+            }
+        }
+        JasperPHP\Instructions::addInstruction(array(
+            "type" => "setCellHeightRatio",
+            "ratio" => $lineHeightRatio
+        ));
 
         JasperPHP\Instructions::addInstruction(array(
             "type" => "SetXY",


### PR DESCRIPTION
You may analise this changes more carefully before accepting it, I tested on some elements and on my reports.

Main change is that instead of removing the text from the element it uses `$pdf->StartTransform()` to crop it to the dimensions of the element (if not stretch)

Another change is that it always uses MultiCell, giving a behavior more similar to the original JasperReports, allowing multiline on every text element.