### PR TITLE
Update StaticText.php

### DIFF
--- a/src/StaticText.php
+++ b/src/StaticText.php
@@ -93,7 +93,7 @@ class StaticText extends Element {
         if (isset($data->textElement->font["isUnderline"]) && $data->textElement->font["isUnderline"] == "true") {
             $fontstyle = $fontstyle . "U";
         }
-        if (isset($data->reportElement["key"])) {
+        if (isset($data->reportElement["key"]) && !empty($data->reportElement["key"])) {
             $height = $fontsize * $this->adjust;
         }
         $lineHeightRatio = 1;


### PR DESCRIPTION
I was reducing the static text's height to less than the default height, because the 'key' property can be empty and it makes the condition true because it only considers the exist, so in addition to existing it confirms if it is not empty