### PR TITLE
Update StaticText.php

### DIFF
--- a/src/StaticText.php
+++ b/src/StaticText.php
@@ -189,7 +189,7 @@ class StaticText extends Element {
      * @param unknown $box
      * @return Array[]
      */
-    public function formatBox($box)
+    public static function formatBox($box)
     {
         $border = Array();
         $borderset = "";


### PR DESCRIPTION
remove:
Deprecated: Non-static method JasperPHP\StaticText::formatBox() should not be called statically in