### PR TITLE
Update Report.php - support changing decimal and thousand separators

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -21,6 +21,8 @@ class Report extends Element {
 
     public static $defaultFolder = 'app.jrxml';
     public static $locale = 'en_us';
+    public static $dec_point=".";
+    public static $thousands_sep=",";
     public $dbData;
     public $arrayVariable;
     public $arrayfield;
@@ -480,29 +482,29 @@ class Report extends Element {
             elseif ($pattern == "###0")
                 return number_format($txt, 0, "", "");
             elseif ($pattern == "#.##0")
-                return number_format($txt, 0, ".", ",");
+                return number_format($txt, 0, self::$dec_point, self::$thousands_sep);
             elseif ($pattern == "###0.0")
-                return number_format($txt, 1, ".", "");
+                return number_format($txt, 1, self::$dec_point, "");
             elseif ($pattern == "#,##0.0" || $pattern == "#,##0.0;-#,##0.0")
-                return number_format($txt, 1, ".", ",");
+                return number_format($txt, 1, self::$dec_point, self::$thousands_sep);
             elseif ($pattern == "###0.00" || $pattern == "###0.00;-###0.00")
-                return number_format($txt, 2, ".", "");
+                return number_format($txt, 2, self::$dec_point, "");
             elseif ($pattern == "#,##0.00" || $pattern == "#,##0.00;-#,##0.00")
-                return number_format($txt, 2, ".", ",");
+                return number_format($txt, 2, self::$dec_point, self::$thousands_sep);
             elseif ($pattern == "###0.00;(###0.00)")
-                return ($txt < 0 ? "(" . number_format(abs($txt), 2, ".", "") . ")" : number_format($txt, 2, ".", ""));
+                return ($txt < 0 ? "(" . number_format(abs($txt), 2, self::$dec_point, "") . ")" : number_format($txt, 2, self::$dec_point, ""));
             elseif ($pattern == "#,##0.00;(#,##0.00)")
-                return ($txt < 0 ? "(" . number_format(abs($txt), 2, ".", ",") . ")" : number_format($txt, 2, ".", ","));
+                return ($txt < 0 ? "(" . number_format(abs($txt), 2, self::$dec_point, self::$thousands_sep) . ")" : number_format($txt, 2, self::$dec_point, self::$thousands_sep));
             elseif ($pattern == "#,##0.00;(-#,##0.00)")
-                return ($txt < 0 ? "(" . number_format($txt, 2, ".", ",") . ")" : number_format($txt, 2, ".", ","));
+                return ($txt < 0 ? "(" . number_format($txt, 2, self::$dec_point, ",") . ")" : number_format($txt, 2, ".", ","));
             elseif ($pattern == "###0.000")
-                return number_format($txt, 3, ".", "");
+                return number_format($txt, 3, self::$dec_point, "");
             elseif ($pattern == "#,##0.000")
-                return number_format($txt, 3, ".", ",");
+                return number_format($txt, 3, self::$dec_point, self::$thousands_sep);
             elseif ($pattern == "#,##0.0000")
-                return number_format($txt, 4, ".", ",");
+                return number_format($txt, 4, self::$dec_point, self::$thousands_sep);
             elseif ($pattern == "###0.0000")
-                return number_format($txt, 4, ".", "");
+                return number_format($txt, 4, self::$dec_point, self::$thousands_sep);
 
             // latin formats
             elseif ($pattern == "#,##0")

--- a/src/Report.php
+++ b/src/Report.php
@@ -504,7 +504,7 @@ class Report extends Element {
             elseif ($pattern == "#,##0.0000")
                 return number_format($txt, 4, self::$dec_point, self::$thousands_sep);
             elseif ($pattern == "###0.0000")
-                return number_format($txt, 4, self::$dec_point, self::$thousands_sep);
+                return number_format($txt, 4, self::$dec_point, "");
 
             // latin formats
             elseif ($pattern == "#,##0")

--- a/src/Report.php
+++ b/src/Report.php
@@ -496,7 +496,7 @@ class Report extends Element {
             elseif ($pattern == "#,##0.00;(#,##0.00)")
                 return ($txt < 0 ? "(" . number_format(abs($txt), 2, self::$dec_point, self::$thousands_sep) . ")" : number_format($txt, 2, self::$dec_point, self::$thousands_sep));
             elseif ($pattern == "#,##0.00;(-#,##0.00)")
-                return ($txt < 0 ? "(" . number_format($txt, 2, self::$dec_point, ",") . ")" : number_format($txt, 2, ".", ","));
+                return ($txt < 0 ? "(" . number_format($txt, 2, self::$dec_point, self::$thousands_sep) . ")" : number_format($txt, 2, self::$dec_point, self::$thousands_sep));
             elseif ($pattern == "###0.000")
                 return number_format($txt, 3, self::$dec_point, "");
             elseif ($pattern == "#,##0.000")


### PR DESCRIPTION
Just look at my suggestion, with this change and setting the decimal and thousands separators as a property of the class, this maintains compatibility with the project definitions, not affecting those who already use the established masking pattern, as it has not changed the latin format of mask, however this way allows the user to use the format compatible with the studio report and define the separators when instantiating the Report:
in my case I use the latin format the separators like this:

```
 $this->report = new JasperPHP\Report($xmlFile, $param); 
 $this->report::$dec_point=",";
 $this->report::$thousands_sep=".";
```