### PR TITLE
Update ColumnFooter.php

### DIFF
--- a/src/ColumnFooter.php
+++ b/src/ColumnFooter.php
@@ -19,6 +19,7 @@ class ColumnFooter extends Element {
     public function generate($obj = null) {
         $rowIndex = 0;
         $row = $obj->lastRowData;
+        if (!$row) {return;}
         //if (!$row) {
         //    $row = array();
         //}


### PR DESCRIPTION
See, I believe the column footer should only exist if and only if we have data from the query, so I have situations where I make expressions in column footer and it keeps giving php syntax error, we could just ignore the footer column if it doesn't exist data returned and so the report will be empty even.