### PR TITLE
print when expression fixes and enhancements

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -382,6 +382,8 @@ class Report extends Element {
             }
         } elseif (is_array($val)) {
             return $val;
+        } elseif ($val === false) {
+            return str_ireplace('$F{' . $field . '}', '0', $text);
         } else {
             return str_ireplace(array('$F{' . $field . '}'), array(($val)), $text);
         }

--- a/src/Subreport.php
+++ b/src/Subreport.php
@@ -23,6 +23,20 @@ class Subreport extends Element
         $this->returnValues = array();
         $row = is_object($obj) ? $_POST : $obj[1];
         $obj = is_array($obj) ? $obj[0] : $obj;
+        
+        
+        $print_expression_result = false;
+        $printWhenExpression = (string)$this->objElement->reportElement->printWhenExpression;
+        if ($printWhenExpression != '') {
+            $printWhenExpression = $obj->get_expression($printWhenExpression, $row);
+            eval('if(' . $printWhenExpression . '){$print_expression_result=true;}');
+        } else {
+            $print_expression_result = true;
+        }
+        if ($print_expression_result !== true) {
+            return;
+        }
+        
         $xmlFile = (string) $this->objElement->subreportExpression;
         $xmlFile = str_ireplace(array('"'), array(''), $xmlFile);
         //$rowArray =is_array($row)?$row:get_object_vars($row);


### PR DESCRIPTION
* correctly evaluate calls that return "false" replacing it by 0 (previously it was an empty string that triggered an `eval()` exception.
* evaluate print when expression on subreport element


