### PR TITLE
add support to Laravel DB Facade as data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ See more blog, documentation, and more on https://jasperphp.net
     <li>textfield with html render with data replacement</li>
     <li>active record</li>
     <li>Conditional styles ready too</li>
+    <li>support for Laravel DB Facade adding `<property name="net.sf.jasperreports.data.adapter" value="laravel.sqlsrv"/>` on jrxml files or edit Default data source on report properties on JasperSoft Studio</li>
 </lu>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See more blog, documentation, and more on https://jasperphp.net
     <li>textfield with html render with data replacement</li>
     <li>active record</li>
     <li>Conditional styles ready too</li>
-    <li>support for Laravel DB Facade adding `<property name="net.sf.jasperreports.data.adapter" value="laravel.sqlsrv"/>` on jrxml files or edit Default data source on report properties on JasperSoft Studio</li>
+    <li>support for Laravel DB Facade adding tag `property name="net.sf.jasperreports.data.adapter" value="laravel.sqlsrv"` on jrxml files or edit Default data source on report properties on JasperSoft Studio</li>
 </lu>
 <br>
 

--- a/app.jrxml/testReport.jrxml
+++ b/app.jrxml/testReport.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.9.0.final using JasperReports Library version 6.9.0-cb8f9004be492ccc537180b49c026951f4220bf3  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report name" pageWidth="595" pageHeight="842" columnWidth="575" leftMargin="10" rightMargin="10" topMargin="10" bottomMargin="10" uuid="578900e3-0c5e-4102-8e31-dc6c573ab805">
+<!-- Created with Jaspersoft Studio version 6.20.6.final using JasperReports Library version 6.20.6-5c96b6aa8a39ac1dc6b6bea4b81168e16dd39231  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report name" pageWidth="595" pageHeight="842" columnWidth="575" leftMargin="10" rightMargin="10" topMargin="10" bottomMargin="10" isIgnorePagination="true" uuid="578900e3-0c5e-4102-8e31-dc6c573ab805">
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="80"/>
@@ -16,6 +16,7 @@
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
 	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="net.sf.jasperreports.data.adapter" value="laravel.sqlsrv"/>
 	<parameter name="locacoes_dia_repasse" class="java.lang.String"/>
 	<parameter name="eventos_mes_ref" class="java.lang.String"/>
 	<queryString>


### PR DESCRIPTION
support for Laravel DB Facade adding tag `property name="net.sf.jasperreports.data.adapter" value="laravel.sqlsrv"` on jrxml files or edit Default data source on report properties on JasperSoft Studio