### PR TITLE
Fixes working with PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.3.0" ,
-        "tecnickcom/tcpdf":"6.3.*"
+        "tecnickcom/tcpdf":"^6.3.5"
     },
     "config": {}
 }

--- a/src/PdfProcessor.php
+++ b/src/PdfProcessor.php
@@ -199,7 +199,7 @@ class PdfProcessor {
     	//draw only border
 	if(isset($arraydata['border']['width']) && $arraydata['border']['width']>0){		
 		JasperPHP\Instructions::$objOutPut->SetLineStyle($arraydata['border']);
-		JasperPHP\Instructions::$objOutPut->RoundedRect($arraydata["x"] + JasperPHP\Instructions::$arrayPageSetting["leftMargin"], $arraydata["y"] + JasperPHP\Instructions::$y_axis, $arraydata["width"], $arraydata["height"], $arraydata["radius"], '1111',$arraydata['border']);		
+		JasperPHP\Instructions::$objOutPut->RoundedRect($arraydata["x"] + JasperPHP\Instructions::$arrayPageSetting["leftMargin"], $arraydata["y"] + JasperPHP\Instructions::$y_axis, $arraydata["width"], $arraydata["height"], $arraydata["radius"], '1111', $style, $arraydata['border']);		
 		JasperPHP\Instructions::$objOutPut->SetLineStyle(array());
 	}
     }
@@ -567,7 +567,7 @@ class PdfProcessor {
 
                 $x = $pdf->GetX();
                 $yAfter = $pdf->GetY();
-                $maxheight = array_key_exists('maxheight', $arraydata) ? $arraydata['maxheight'] : '';
+                $maxheight = array_key_exists('maxheight', $arraydata) ? $arraydata['maxheight'] : 0;
                 //if($arraydata["link"])   echo $arraydata["linktarget"].",".$arraydata["link"]."<br/><br/>";
                 $pdf->MultiCell($w, $h, $JasperObj->formatText($txt, $arraydata["pattern"]), $arraydata["border"]
                         , $arraydata["align"], $arraydata["fill"], 1, $x, $y, true, 0, false, true, $maxheight); //,$arraydata["valign"]);

--- a/src/StaticText.php
+++ b/src/StaticText.php
@@ -196,13 +196,13 @@ class StaticText extends Element {
     {
         $border = Array();
         $borderset = "";
-        if ($box->topPen["lineWidth"] > 0)
+        if ($box->topPen["lineWidth"] > 0.0)
             $border["T"] = StaticText::formatPen($box->topPen);
-        if ($box->leftPen["lineWidth"] > 0)
+        if ($box->leftPen["lineWidth"] > 0.0)
             $border["L"] = StaticText::formatPen($box->leftPen);
-        if ($box->bottomPen["lineWidth"] > 0)
+        if ($box->bottomPen["lineWidth"] > 0.0)
             $border["B"] = StaticText::formatPen($box->bottomPen);
-        if ($box->rightPen["lineWidth"] > 0)
+        if ($box->rightPen["lineWidth"] > 0.0)
             $border["R"] = StaticText::formatPen($box->rightPen);
 
         return $border;

--- a/src/Table.php
+++ b/src/Table.php
@@ -73,16 +73,16 @@ class Table extends Element
   
 	
 		//top border cell
-        if (isset($box->topPen["lineWidth"]) && $box->topPen["lineWidth"]>0)			
+        if (isset($box->topPen["lineWidth"]) && $box->topPen["lineWidth"]>0.0)			
             $border['T']=$this->formatPen($box,$box->topPen);
 		//leftPen border cell
-        if (isset($box->leftPen["lineWidth"]) && $box->leftPen["lineWidth"]>0)			
+        if (isset($box->leftPen["lineWidth"]) && $box->leftPen["lineWidth"]>0.0)			
             $border['L']=$this->formatPen($box,$box->leftPen);
 		//bottomPen border cell		
-        if (isset($box->bottomPen["lineWidth"]) && $box->bottomPen["lineWidth"]>0)			
+        if (isset($box->bottomPen["lineWidth"]) && $box->bottomPen["lineWidth"]>0.0)			
             $border['B']=$this->formatPen($box,$box->bottomPen);
 		//rightPen border cell
-        if (isset($box->rightPen["lineWidth"]) && $box->rightPen["lineWidth"]>0)			
+        if (isset($box->rightPen["lineWidth"]) && $box->rightPen["lineWidth"]>0.0)
             $border['R']=$this->formatPen($box,$box->rightPen);		
 		return $border;		
 	}


### PR DESCRIPTION
I've added three commits, two of them fixes behavior of JasperPHP with php8.2:

* missing parameter when working with rectangles and with fields with StretchHeight property active
* borders smaller than 1 on static fields, text fields and table cells

Also added a change to the TCPDF version constraint to allow any version between >=6.3.5 and <7, this will avoid any breaking changes and allow the use of the latest release inside the 6 major version.
