### PR TITLE
Alterações para php 8.2

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -13,15 +13,15 @@ namespace JasperPHP;
 	use JasperPHP;
 	class Element
 	{
-		public $objElement;
-		public $children;
-
 		private $properties;    // propriedades da TAG 
 		private $name;
 		private $height;
 		private $splitType;
 		private $radius;
 		private $scaleImage;
+		
+		public $objElement;
+		public $children;
 
 		public function __construct($ObjElement)
 		{

--- a/src/Element.php
+++ b/src/Element.php
@@ -13,11 +13,15 @@ namespace JasperPHP;
 	use JasperPHP;
 	class Element
 	{
-		private $properties;    // propriedades da TAG 
 		public $objElement;
 		public $children;
 
-
+		private $properties;    // propriedades da TAG 
+		private $name;
+		private $height;
+		private $splitType;
+		private $radius;
+		private $scaleImage;
 
 		public function __construct($ObjElement)
 		{

--- a/src/Report.php
+++ b/src/Report.php
@@ -40,8 +40,15 @@ class Report extends Element {
     public $rowData;
     public $lastRowData;
     public $arrayStyles;
+	
+    private $name;
+    private $height;
+    private $splitType;
+    private $radius;
+    private $scaleImage;
+    private $y_axis;
 
-    public function __construct($xmlFile = null, $param) {
+    public function __construct($xmlFile, $param) {
         if (file_exists(self::$defaultFolder . DIRECTORY_SEPARATOR . $xmlFile)) {
             $xmlFile = file_get_contents(self::$defaultFolder . DIRECTORY_SEPARATOR . $xmlFile);
         } elseif (file_exists($xmlFile)) {

--- a/src/Report.php
+++ b/src/Report.php
@@ -18,7 +18,13 @@ use JasperPHP\ado\TTransaction;
  * 2015.03.11 -- criação
  * */
 class Report extends Element {
-
+    private $name;
+    private $height;
+    private $splitType;
+    private $radius;
+    private $scaleImage;
+    private $y_axis;
+	
     public static $defaultFolder = 'app.jrxml';
     public static $locale = 'en_us';
     public static $dec_point=".";
@@ -40,13 +46,6 @@ class Report extends Element {
     public $rowData;
     public $lastRowData;
     public $arrayStyles;
-	
-    private $name;
-    private $height;
-    private $splitType;
-    private $radius;
-    private $scaleImage;
-    private $y_axis;
 
     public function __construct($xmlFile, $param) {
         if (file_exists(self::$defaultFolder . DIRECTORY_SEPARATOR . $xmlFile)) {


### PR DESCRIPTION
Corrige os avisos de deprecated com php 8.2. Testei somente com itau.
ex.: Creation of dynamic property JasperPHP\Image::$scaleImage is deprecated 