### PR TITLE
Patch 39

### DIFF
--- a/src/ado/TConnection.php
+++ b/src/ado/TConnection.php
@@ -27,18 +27,12 @@ final class TConnection
      */
     public static function open($name)
     {
-        if (file_exists($name))
-        {
-            $db = parse_ini_file($name);
-        }
-        elseif (file_exists("config/{$name}.ini"))
-        {
-            $db = parse_ini_file("config/{$name}.ini");
-        }
-        else
-        {
-            throw new Exception("Arquivo '$name' não encontrado");
-        }
+        $db = self::getDatabaseInfo($name);
+        return self::openArray($db);
+    }
+   
+    public static function openArray($db)
+    {
         $user = isset($db['user']) ? $db['user'] : NULL;
         $pass = isset($db['pass']) ? $db['pass'] : NULL;
         $name = isset($db['name']) ? $db['name'] : NULL;
@@ -72,5 +66,22 @@ final class TConnection
         }
         $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         return $conn;
-    }
+    } 
+    
+  public static function getDatabaseInfo($name)
+    {
+       if (file_exists($name))
+        {
+            $db = parse_ini_file($name);
+        }
+        elseif (file_exists("config/{$name}.ini"))
+        {
+            $db = parse_ini_file("config/{$name}.ini");
+        }
+        else
+        {
+            throw new Exception("Arquivo '$name' não encontrado");
+        }
+        return $db;
+    }   
 }

--- a/src/ado/TTransaction.php
+++ b/src/ado/TTransaction.php
@@ -28,20 +28,27 @@ final class TTransaction
      * método open()
      * Abre uma transação e uma conexão ao BD
      * @param $database = nome do banco de dados
-     * @param $fake = se deseja abrir uma conexão somente leitura evita deadlock
+     * @param $dbinfo = conexão via array
      */
-    public static function open($database, $fake=false)
+    public static function open($database, $dbinfo = NULL)
     {
         // abre uma conexão e armazena na propriedade estática $conn
         if (empty(self::$conn))
         {
-            self::$conn = TConnection::open($database);
-            //informa se a conexão é fake
-            self::$fake = $fake;
-            // inicia a transação
+            if ($dbinfo)
+            {
+                self::$conn = TConnection::openArray($dbinfo);                
+            }else{
+                $dbinfo = TConnection::getDatabaseInfo($database);
+                self::$conn = TConnection::open($database);                
+            }
+            
+            //verifica se a conexão é fake [evita locks tables]
+            self::$fake = isset($dbinfo['fake']) ? $dbinfo['fake'] : FALSE;
             if(!self::$fake){
                 self::$conn->beginTransaction();
             }
+            
             // desliga o log de SQL
             self::$logger = NULL;
         }


### PR DESCRIPTION
suporte a abrir uma conexão com um array, com dados da conexão
ex:
$db= [
    'host'   => "localhost",
    'port'   => "3306",
    'name'   => "banco",
    'user'   => "root",
    'pass'   => "senha",
    'type'   => "mysql"
];

JasperPHP\ado\TTransaction::open(null, $db); 

porem mantendo compatibilidade, além disso o parametro
"fake", pode ser habilitado tanto no arquivo "ini" quanto direto no array $db, para evitar locks...

isso torna mais fácil e dinâmico a abertura de conexão