### PR TITLE
Update TTransaction.php

### DIFF
--- a/src/ado/TTransaction.php
+++ b/src/ado/TTransaction.php
@@ -54,6 +54,18 @@ final class TTransaction
         }
     }    
 
+    /**
+     * Open fake transaction
+     * @param $database Name of the database (an INI file).
+     */
+    public static function openFake($database)
+    {
+        $info = TConnection::getDatabaseInfo($database);
+        $info['fake'] = 1;
+        
+        self::open(null, $info);
+    }
+	
     
     /*
      * método get()
@@ -119,4 +131,3 @@ final class TTransaction
         }
     }
 }
-?>


### PR DESCRIPTION
Facilitar a abertura de uma fake conection
adiciona o suporte ao chamar
TTransaction::openFake('dev');

assim realiza a abertura da conexão, porem informando que é um fake, sem causar incompatibilidade, pois é uma opção a mais...